### PR TITLE
RMX1805: Disable debug.sf.latch_unsignaled

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -24,7 +24,7 @@ DEVICE_PROVISIONED=1
 ro.telephony.default_network=22,20
 
 debug.sf.hw=0
-debug.sf.latch_unsignaled=1
+debug.sf.latch_unsignaled=0
 debug.egl.hw=0
 persist.hwc.mdpcomp.enable=true
 debug.mdpcomp.logs=0


### PR DESCRIPTION
* Disabling this helps reduces notification flicker, UI performance is not impacted.
(per:  change https://android.googlesource.com/platform/frameworks/native/+/c5da271)

* Fix mad lags on live wallpapers

Signed-off-by: Andrew Hexen <SyberHexen@gmail.com>
Signed-off-by: fakeyatogod <fakeyatokami@gmail.com>

Change-Id: I8b7aed9bc5ff03bd8d1cd05f70c8568c1faf971c